### PR TITLE
Use calibrated units in all flight modes

### DIFF
--- a/cx10_fnrf.uvoptx
+++ b/cx10_fnrf.uvoptx
@@ -162,7 +162,24 @@
           <Name>-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F0xx_32 -FS08000000 -FL08000 -FP0($$Device:STM32F031K6$Flash\STM32F0xx_32.FLM))</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint/>
+      <Breakpoint>
+        <Bp>
+          <Number>0</Number>
+          <Type>0</Type>
+          <LineNumber>158</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>0</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>0</BreakIfRCount>
+          <Filename>.\src\main.c</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression></Expression>
+        </Bp>
+      </Breakpoint>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -279,6 +296,36 @@
           <WinNumber>1</WinNumber>
           <ItemText>rpy[2],0x0A</ItemText>
         </Ww>
+        <Ww>
+          <count>23</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>state</ItemText>
+        </Ww>
+        <Ww>
+          <count>24</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>failsafe</ItemText>
+        </Ww>
+        <Ww>
+          <count>25</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>RXcommands[2],0x0A</ItemText>
+        </Ww>
+        <Ww>
+          <count>26</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>error</ItemText>
+        </Ww>
+        <Ww>
+          <count>27</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>looptime,0x0A</ItemText>
+        </Ww>
+        <Ww>
+          <count>28</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>timer_imu,0x0A</ItemText>
+        </Ww>
       </WatchWindow1>
       <WatchWindow2>
         <Ww>
@@ -338,7 +385,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>1</periodic>
-        <aLwin>1</aLwin>
+        <aLwin>0</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>

--- a/listings/cx10_fnrf.map
+++ b/listings/cx10_fnrf.map
@@ -14,20 +14,18 @@ Section Cross References
     main.o(.text) refers to rfproto.o(.text) for init_rf
     main.o(.text) refers to main.o(i.__ARM_common_switch8) for __ARM_common_switch8
     main.o(.text) refers to imu.o(.text) for update_imu
-    main.o(.text) refers to uidiv.o(.text) for __aeabi_uidivmod
-    main.o(.text) refers to idiv.o(.text) for __aeabi_idivmod
+    main.o(.text) refers to fflti.o(.text) for __aeabi_i2f
     main.o(.text) refers to fmul.o(.text) for __aeabi_fmul
-    main.o(.text) refers to fadd.o(.text) for __aeabi_fsub
-    main.o(.text) refers to asinf.o(i.asinf) for asinf
-    main.o(.text) refers to f2d.o(.text) for __aeabi_f2d
-    main.o(.text) refers to dmul.o(.text) for __aeabi_dmul
-    main.o(.text) refers to d2f.o(.text) for __aeabi_d2f
+    main.o(.text) refers to uidiv.o(.text) for __aeabi_uidivmod
+    main.o(.text) refers to fadd.o(.text) for __aeabi_fadd
     main.o(.text) refers to atan2f.o(i.atan2f) for atan2f
-    main.o(.text) refers to dflti.o(.text) for __aeabi_i2d
+    main.o(.text) refers to asinf.o(i.asinf) for asinf
+    main.o(.text) refers to idiv.o(.text) for __aeabi_idivmod
+    main.o(.text) refers to ffixi.o(.text) for __aeabi_f2iz
     main.o(.text) refers to main.o(.constdata) for .constdata
     main.o(.text) refers to main.o(.data) for state_next
-    main.o(.text) refers to imu.o(.data) for q1
-    main.o(.text) refers to ffixi.o(.text) for __aeabi_f2iz
+    main.o(.text) refers to main.o(.bss) for setpoint
+    main.o(.text) refers to imu.o(.data) for q2
     main.o(.text) refers to stm32f0xx_adc.o(.text) for ADC_StartOfConversion
     blinker.o(.text) refers to main.o(i.__ARM_common_switch8) for __ARM_common_switch8
     blinker.o(.text) refers to stm32f0xx_gpio.o(.text) for GPIO_WriteBit
@@ -198,16 +196,9 @@ Section Cross References
     fadd.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
     fadd.o(.text) refers to fepilogue.o(.text) for _float_epilogue
     fmul.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
-    dmul.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
-    dmul.o(.text) refers to depilogue.o(.text) for _double_epilogue
     fflti.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
     fflti.o(.text) refers to fepilogue.o(.text) for _float_epilogue
-    dflti.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
-    dflti.o(.text) refers to depilogue.o(.text) for _double_epilogue
     ffixi.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
-    f2d.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
-    d2f.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
-    d2f.o(.text) refers to fepilogue.o(.text) for _float_round
     cfcmple.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
     cfrcmple.o(.text) refers (Special) to iusefp.o(.text) for __I$use$fp
     fpclassifyf.o(i.__ARM_fpclassifyf) refers (Special) to iusefp.o(.text) for __I$use$fp
@@ -241,9 +232,6 @@ Section Cross References
     errno.o(i.__read_errno) refers to errno.o(.data) for .data
     errno.o(i.__set_errno) refers to errno.o(.data) for .data
     fdiv.o(.text) refers to fepilogue.o(.text) for _float_round
-    depilogue.o(.text) refers to depilogue.o(i.__ARM_clz) for __ARM_clz
-    depilogue.o(.text) refers to llshl.o(.text) for __aeabi_llsl
-    depilogue.o(.text) refers to llushr.o(.text) for __aeabi_llsr
     init.o(.text) refers to entry5.o(.ARM.Collect$$$$00000004) for __main_after_scatterload
     fsqrt.o(.text) refers to fepilogue.o(.text) for _float_round
 
@@ -784,45 +772,38 @@ Image Symbol Table
     ../clib/microlib/division.c              0x00000000   Number         0  uidiv.o ABSOLUTE
     ../clib/microlib/division.c              0x00000000   Number         0  idiv.o ABSOLUTE
     ../clib/microlib/errno.c                 0x00000000   Number         0  errno.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry7b.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry5.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry2.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry11b.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry11a.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry10b.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry7a.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry9b.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry10a.o ABSOLUTE
     ../clib/microlib/init/entry.s            0x00000000   Number         0  entry9a.o ABSOLUTE
-    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry2.o ABSOLUTE
     ../clib/microlib/init/entry.s            0x00000000   Number         0  entry8b.o ABSOLUTE
     ../clib/microlib/init/entry.s            0x00000000   Number         0  entry8a.o ABSOLUTE
-    ../clib/microlib/longlong.c              0x00000000   Number         0  llushr.o ABSOLUTE
-    ../clib/microlib/longlong.c              0x00000000   Number         0  llshl.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry10b.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry7b.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry11b.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry11a.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry7a.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry10a.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry9b.o ABSOLUTE
+    ../clib/microlib/init/entry.s            0x00000000   Number         0  entry5.o ABSOLUTE
     ../clib/microlib/string/memcpy.c         0x00000000   Number         0  memcpyb.o ABSOLUTE
     ../clib/microlib/string/memcpy.c         0x00000000   Number         0  memcpya.o ABSOLUTE
     ../clib/microlib/stubs.s                 0x00000000   Number         0  iusefp.o ABSOLUTE
-    ../fplib/microlib/d2f.c                  0x00000000   Number         0  d2f.o ABSOLUTE
-    ../fplib/microlib/f2d.c                  0x00000000   Number         0  f2d.o ABSOLUTE
     ../fplib/microlib/fpadd.c                0x00000000   Number         0  fadd.o ABSOLUTE
     ../fplib/microlib/fpdiv.c                0x00000000   Number         0  fdiv.o ABSOLUTE
-    ../fplib/microlib/fpepilogue.c           0x00000000   Number         0  depilogue.o ABSOLUTE
     ../fplib/microlib/fpepilogue.c           0x00000000   Number         0  fepilogue.o ABSOLUTE
     ../fplib/microlib/fpfix.c                0x00000000   Number         0  ffixi.o ABSOLUTE
-    ../fplib/microlib/fpflt.c                0x00000000   Number         0  dflti.o ABSOLUTE
     ../fplib/microlib/fpflt.c                0x00000000   Number         0  fflti.o ABSOLUTE
-    ../fplib/microlib/fpmul.c                0x00000000   Number         0  dmul.o ABSOLUTE
     ../fplib/microlib/fpmul.c                0x00000000   Number         0  fmul.o ABSOLUTE
     ../fplib/microlib/fpscalb.c              0x00000000   Number         0  fscalb.o ABSOLUTE
     ../fplib/microlib/fpsqrt.c               0x00000000   Number         0  fsqrt.o ABSOLUTE
     ../mathlib/asinf.c                       0x00000000   Number         0  asinf.o ABSOLUTE
     ../mathlib/asinf.c                       0x00000000   Number         0  asinf_x.o ABSOLUTE
-    ../mathlib/atan2f.c                      0x00000000   Number         0  atan2f.o ABSOLUTE
     ../mathlib/atan2f.c                      0x00000000   Number         0  atan2f_x.o ABSOLUTE
+    ../mathlib/atan2f.c                      0x00000000   Number         0  atan2f.o ABSOLUTE
     ../mathlib/fpclassifyf.c                 0x00000000   Number         0  fpclassifyf.o ABSOLUTE
     ../mathlib/funder.c                      0x00000000   Number         0  funder.o ABSOLUTE
-    ../mathlib/sqrtf.c                       0x00000000   Number         0  sqrtf.o ABSOLUTE
     ../mathlib/sqrtf.c                       0x00000000   Number         0  sqrtf_x.o ABSOLUTE
+    ../mathlib/sqrtf.c                       0x00000000   Number         0  sqrtf.o ABSOLUTE
     Libraries\STM32F0xx_StdPeriph_Driver\src\stm32f0xx_adc.c 0x00000000   Number         0  stm32f0xx_adc.o ABSOLUTE
     Libraries\STM32F0xx_StdPeriph_Driver\src\stm32f0xx_cec.c 0x00000000   Number         0  stm32f0xx_cec.o ABSOLUTE
     Libraries\STM32F0xx_StdPeriph_Driver\src\stm32f0xx_comp.c 0x00000000   Number         0  stm32f0xx_comp.o ABSOLUTE
@@ -904,109 +885,107 @@ Image Symbol Table
     .ARM.Collect$$$$00002712                 0x080000d0   Section        4  entry2.o(.ARM.Collect$$$$00002712)
     __lit__00000000                          0x080000d0   Data           4  entry2.o(.ARM.Collect$$$$00002712)
     .text                                    0x080000d4   Section        0  main.o(.text)
-    .text                                    0x080007b0   Section        0  blinker.o(.text)
-    .text                                    0x08000944   Section        0  mpu6050.o(.text)
-    .text                                    0x08000df0   Section        0  adc.o(.text)
-    .text                                    0x08000ea4   Section        0  timer.o(.text)
-    .text                                    0x08000f54   Section        0  stm32f0xx_it.o(.text)
-    .text                                    0x08000f60   Section        0  system_stm32f0xx.o(.text)
-    SetSysClock                              0x08000f61   Thumb Code   118  system_stm32f0xx.o(.text)
-    .text                                    0x08001054   Section        0  nrf24.o(.text)
-    spiSendByte                              0x08001055   Thumb Code    48  nrf24.o(.text)
-    spiReceiveByte                           0x08001085   Thumb Code    10  nrf24.o(.text)
-    .text                                    0x08001498   Section        0  motorpwm.o(.text)
-    .text                                    0x08001620   Section        0  rfproto.o(.text)
-    .text                                    0x08001c08   Section        0  imu.o(.text)
-    .text                                    0x08002064   Section        0  stm32f0xx_adc.o(.text)
-    .text                                    0x0800214c   Section        0  stm32f0xx_gpio.o(.text)
-    .text                                    0x0800224c   Section        0  stm32f0xx_i2c.o(.text)
-    .text                                    0x08002324   Section        0  stm32f0xx_rcc.o(.text)
-    .text                                    0x080023b4   Section        0  stm32f0xx_spi.o(.text)
-    .text                                    0x08002464   Section        0  stm32f0xx_tim.o(.text)
-    TI4_Config                               0x080027bd   Thumb Code    66  stm32f0xx_tim.o(.text)
-    TI3_Config                               0x080027ff   Thumb Code    66  stm32f0xx_tim.o(.text)
-    TI2_Config                               0x08002841   Thumb Code   148  stm32f0xx_tim.o(.text)
-    TI1_Config                               0x080028d5   Thumb Code    54  stm32f0xx_tim.o(.text)
-    .text                                    0x08002924   Section        0  stm32f0xx_misc.o(.text)
-    .text                                    0x08002994   Section       88  startup_stm32f0xx_mdk_arm.o(.text)
-    .text                                    0x080029ec   Section        0  uidiv.o(.text)
-    .text                                    0x08002a18   Section        0  idiv.o(.text)
-    .text                                    0x08002a40   Section        0  memcpya.o(.text)
-    .text                                    0x08002a64   Section        0  fadd.o(.text)
-    .text                                    0x08002b16   Section        0  fmul.o(.text)
-    .text                                    0x08002b90   Section        0  dmul.o(.text)
-    .text                                    0x08002c60   Section        0  fflti.o(.text)
-    .text                                    0x08002c78   Section        0  dflti.o(.text)
-    .text                                    0x08002ca0   Section        0  ffixi.o(.text)
-    .text                                    0x08002cd2   Section        0  f2d.o(.text)
-    .text                                    0x08002cfa   Section        0  d2f.o(.text)
-    .text                                    0x08002d34   Section       20  cfcmple.o(.text)
-    .text                                    0x08002d48   Section       20  cfrcmple.o(.text)
-    .text                                    0x08002d5c   Section        0  iusefp.o(.text)
-    .text                                    0x08002d5c   Section        0  fepilogue.o(.text)
-    .text                                    0x08002dde   Section        0  fdiv.o(.text)
-    .text                                    0x08002e5a   Section        0  fscalb.o(.text)
-    .text                                    0x08002e72   Section        0  depilogue.o(.text)
-    .text                                    0x08002f30   Section       36  init.o(.text)
-    .text                                    0x08002f54   Section        0  llshl.o(.text)
-    .text                                    0x08002f74   Section        0  llushr.o(.text)
-    .text                                    0x08002f96   Section        0  fsqrt.o(.text)
-    i.__ARM_clz                              0x08002fee   Section        0  depilogue.o(i.__ARM_clz)
-    i.__ARM_common_switch8                   0x0800301c   Section        0  main.o(i.__ARM_common_switch8)
-    i.__ARM_fpclassifyf                      0x08003038   Section        0  fpclassifyf.o(i.__ARM_fpclassifyf)
-    i.__mathlib_flt_infnan                   0x0800305a   Section        0  funder.o(i.__mathlib_flt_infnan)
-    i.__mathlib_flt_infnan2                  0x08003064   Section        0  funder.o(i.__mathlib_flt_infnan2)
-    i.__mathlib_flt_invalid                  0x0800306c   Section        0  funder.o(i.__mathlib_flt_invalid)
-    i.__mathlib_flt_underflow                0x08003078   Section        0  funder.o(i.__mathlib_flt_underflow)
-    i.__scatterload_copy                     0x08003086   Section       14  handlers.o(i.__scatterload_copy)
-    i.__scatterload_null                     0x08003094   Section        2  handlers.o(i.__scatterload_null)
-    i.__scatterload_zeroinit                 0x08003096   Section       14  handlers.o(i.__scatterload_zeroinit)
-    i.__set_errno                            0x080030a4   Section        0  errno.o(i.__set_errno)
-    i.asinf                                  0x080030b0   Section        0  asinf.o(i.asinf)
-    i.atan2f                                 0x080031c8   Section        0  atan2f.o(i.atan2f)
-    i.sqrtf                                  0x08003424   Section        0  sqrtf.o(i.sqrtf)
-    .constdata                               0x08003450   Section       32  main.o(.constdata)
-    RPY_Rate                                 0x08003450   Data           3  main.o(.constdata)
-    Imax                                     0x08003454   Data           6  main.o(.constdata)
-    G_P                                      0x0800345a   Data           3  main.o(.constdata)
-    G_I                                      0x0800345d   Data           3  main.o(.constdata)
-    G_D                                      0x08003460   Data           3  main.o(.constdata)
-    .constdata                               0x08003470   Section       22  rfproto.o(.constdata)
-    demod_cal                                0x08003475   Data           5  rfproto.o(.constdata)
-    rf_cal                                   0x0800347a   Data           7  rfproto.o(.constdata)
-    bb_cal                                   0x08003481   Data           5  rfproto.o(.constdata)
-    .data                                    0x20000000   Section       38  main.o(.data)
-    setpoint                                 0x20000004   Data           6  main.o(.data)
-    timer_imu                                0x2000000c   Data           4  main.o(.data)
-    imu_pitch                                0x20000010   Data           4  main.o(.data)
-    imu_roll                                 0x20000014   Data           4  main.o(.data)
-    imu_yaw                                  0x20000018   Data           4  main.o(.data)
-    req_pitch                                0x2000001c   Data           4  main.o(.data)
-    req_roll                                 0x20000020   Data           4  main.o(.data)
+    .text                                    0x080006c4   Section        0  blinker.o(.text)
+    .text                                    0x08000858   Section        0  mpu6050.o(.text)
+    .text                                    0x08000d1c   Section        0  adc.o(.text)
+    .text                                    0x08000dd0   Section        0  timer.o(.text)
+    .text                                    0x08000e80   Section        0  stm32f0xx_it.o(.text)
+    .text                                    0x08000e8c   Section        0  system_stm32f0xx.o(.text)
+    SetSysClock                              0x08000e8d   Thumb Code   118  system_stm32f0xx.o(.text)
+    .text                                    0x08000f80   Section        0  nrf24.o(.text)
+    spiSendByte                              0x08000f81   Thumb Code    48  nrf24.o(.text)
+    spiReceiveByte                           0x08000fb1   Thumb Code    10  nrf24.o(.text)
+    .text                                    0x080013c4   Section        0  motorpwm.o(.text)
+    .text                                    0x0800154c   Section        0  rfproto.o(.text)
+    .text                                    0x08001b40   Section        0  imu.o(.text)
+    .text                                    0x08001f9c   Section        0  stm32f0xx_adc.o(.text)
+    .text                                    0x08002084   Section        0  stm32f0xx_gpio.o(.text)
+    .text                                    0x08002184   Section        0  stm32f0xx_i2c.o(.text)
+    .text                                    0x0800225c   Section        0  stm32f0xx_rcc.o(.text)
+    .text                                    0x080022ec   Section        0  stm32f0xx_spi.o(.text)
+    .text                                    0x0800239c   Section        0  stm32f0xx_tim.o(.text)
+    TI4_Config                               0x080026f5   Thumb Code    66  stm32f0xx_tim.o(.text)
+    TI3_Config                               0x08002737   Thumb Code    66  stm32f0xx_tim.o(.text)
+    TI2_Config                               0x08002779   Thumb Code   148  stm32f0xx_tim.o(.text)
+    TI1_Config                               0x0800280d   Thumb Code    54  stm32f0xx_tim.o(.text)
+    .text                                    0x0800285c   Section        0  stm32f0xx_misc.o(.text)
+    .text                                    0x080028cc   Section       88  startup_stm32f0xx_mdk_arm.o(.text)
+    .text                                    0x08002924   Section        0  uidiv.o(.text)
+    .text                                    0x08002950   Section        0  idiv.o(.text)
+    .text                                    0x08002978   Section        0  memcpya.o(.text)
+    .text                                    0x0800299c   Section        0  fadd.o(.text)
+    .text                                    0x08002a4e   Section        0  fmul.o(.text)
+    .text                                    0x08002ac8   Section        0  fflti.o(.text)
+    .text                                    0x08002ade   Section        0  ffixi.o(.text)
+    .text                                    0x08002b10   Section       20  cfcmple.o(.text)
+    .text                                    0x08002b24   Section       20  cfrcmple.o(.text)
+    .text                                    0x08002b38   Section        0  iusefp.o(.text)
+    .text                                    0x08002b38   Section        0  fepilogue.o(.text)
+    .text                                    0x08002bba   Section        0  fdiv.o(.text)
+    .text                                    0x08002c36   Section        0  fscalb.o(.text)
+    .text                                    0x08002c50   Section       36  init.o(.text)
+    .text                                    0x08002c74   Section        0  fsqrt.o(.text)
+    i.__ARM_common_switch8                   0x08002ccc   Section        0  main.o(i.__ARM_common_switch8)
+    i.__ARM_fpclassifyf                      0x08002ce8   Section        0  fpclassifyf.o(i.__ARM_fpclassifyf)
+    i.__mathlib_flt_infnan                   0x08002d0a   Section        0  funder.o(i.__mathlib_flt_infnan)
+    i.__mathlib_flt_infnan2                  0x08002d14   Section        0  funder.o(i.__mathlib_flt_infnan2)
+    i.__mathlib_flt_invalid                  0x08002d1c   Section        0  funder.o(i.__mathlib_flt_invalid)
+    i.__mathlib_flt_underflow                0x08002d28   Section        0  funder.o(i.__mathlib_flt_underflow)
+    i.__scatterload_copy                     0x08002d36   Section       14  handlers.o(i.__scatterload_copy)
+    i.__scatterload_null                     0x08002d44   Section        2  handlers.o(i.__scatterload_null)
+    i.__scatterload_zeroinit                 0x08002d46   Section       14  handlers.o(i.__scatterload_zeroinit)
+    i.__set_errno                            0x08002d54   Section        0  errno.o(i.__set_errno)
+    i.asinf                                  0x08002d60   Section        0  asinf.o(i.asinf)
+    i.atan2f                                 0x08002e78   Section        0  atan2f.o(i.atan2f)
+    i.sqrtf                                  0x080030d4   Section        0  sqrtf.o(i.sqrtf)
+    .constdata                               0x08003100   Section       32  main.o(.constdata)
+    RPY_Rate                                 0x08003100   Data           3  main.o(.constdata)
+    Imax                                     0x08003104   Data           6  main.o(.constdata)
+    G_P                                      0x0800310a   Data           3  main.o(.constdata)
+    G_I                                      0x0800310d   Data           3  main.o(.constdata)
+    G_D                                      0x08003110   Data           3  main.o(.constdata)
+    .constdata                               0x08003120   Section       22  rfproto.o(.constdata)
+    demod_cal                                0x08003125   Data           5  rfproto.o(.constdata)
+    rf_cal                                   0x0800312a   Data           7  rfproto.o(.constdata)
+    bb_cal                                   0x08003131   Data           5  rfproto.o(.constdata)
+    .data                                    0x20000000   Section       39  main.o(.data)
+    imu_pitch                                0x20000004   Data           4  main.o(.data)
+    imu_roll                                 0x20000008   Data           4  main.o(.data)
+    imu_yaw                                  0x2000000c   Data           4  main.o(.data)
+    req_pitch                                0x20000010   Data           4  main.o(.data)
+    req_roll                                 0x20000014   Data           4  main.o(.data)
+    timer_imu_start                          0x20000018   Data           4  main.o(.data)
+    timer_imu                                0x2000001c   Data           4  main.o(.data)
+    looptime                                 0x20000020   Data           4  main.o(.data)
     state                                    0x20000024   Data           1  main.o(.data)
     state_next                               0x20000025   Data           1  main.o(.data)
-    .data                                    0x20000026   Section        2  blinker.o(.data)
-    blink_style                              0x20000026   Data           1  blinker.o(.data)
-    phase                                    0x20000027   Data           1  blinker.o(.data)
-    .data                                    0x20000028   Section        1  mpu6050.o(.data)
-    i                                        0x20000028   Data           1  mpu6050.o(.data)
-    .data                                    0x2000002a   Section        2  timer.o(.data)
-    T3OV                                     0x2000002a   Data           2  timer.o(.data)
-    .data                                    0x2000002c   Section        8  nrf24.o(.data)
-    isInit                                   0x2000002c   Data           1  nrf24.o(.data)
-    interruptCb                              0x20000030   Data           4  nrf24.o(.data)
-    .data                                    0x20000034   Section        5  rfproto.o(.data)
-    CX10_freq                                0x20000034   Data           4  rfproto.o(.data)
-    CX10_current_chan                        0x20000038   Data           1  rfproto.o(.data)
-    .data                                    0x2000003c   Section       36  imu.o(.data)
-    .data                                    0x20000060   Section        4  errno.o(.data)
-    _errno                                   0x20000060   Data           4  errno.o(.data)
-    .bss                                     0x20000064   Section       24  mpu6050.o(.bss)
-    calibGyro                                0x20000064   Data          12  mpu6050.o(.bss)
-    calibAcc                                 0x20000070   Data          12  mpu6050.o(.bss)
-    .bss                                     0x2000007c   Section       19  rfproto.o(.bss)
-    rxbuffer                                 0x2000007c   Data          19  rfproto.o(.bss)
-    STACK                                    0x20000090   Section     1024  startup_stm32f0xx_mdk_arm.o(STACK)
+    fmode                                    0x20000026   Data           1  main.o(.data)
+    .data                                    0x20000027   Section        2  blinker.o(.data)
+    blink_style                              0x20000027   Data           1  blinker.o(.data)
+    phase                                    0x20000028   Data           1  blinker.o(.data)
+    .data                                    0x2000002a   Section       14  mpu6050.o(.data)
+    i                                        0x2000002a   Data           1  mpu6050.o(.data)
+    GyroXYZ                                  0x2000002c   Data           6  mpu6050.o(.data)
+    ACCXYZ                                   0x20000032   Data           6  mpu6050.o(.data)
+    .data                                    0x20000038   Section        2  timer.o(.data)
+    T3OV                                     0x20000038   Data           2  timer.o(.data)
+    .data                                    0x2000003c   Section        8  nrf24.o(.data)
+    isInit                                   0x2000003c   Data           1  nrf24.o(.data)
+    interruptCb                              0x20000040   Data           4  nrf24.o(.data)
+    .data                                    0x20000044   Section        5  rfproto.o(.data)
+    CX10_freq                                0x20000044   Data           4  rfproto.o(.data)
+    CX10_current_chan                        0x20000048   Data           1  rfproto.o(.data)
+    .data                                    0x2000004c   Section       36  imu.o(.data)
+    .data                                    0x20000070   Section        4  errno.o(.data)
+    _errno                                   0x20000070   Data           4  errno.o(.data)
+    .bss                                     0x20000074   Section       12  main.o(.bss)
+    setpoint                                 0x20000074   Data          12  main.o(.bss)
+    .bss                                     0x20000080   Section       24  mpu6050.o(.bss)
+    calibGyro                                0x20000080   Data          12  mpu6050.o(.bss)
+    calibAcc                                 0x2000008c   Data          12  mpu6050.o(.bss)
+    .bss                                     0x20000098   Section       19  rfproto.o(.bss)
+    rxbuffer                                 0x20000098   Data          19  rfproto.o(.bss)
+    STACK                                    0x200000b0   Section     1024  startup_stm32f0xx_mdk_arm.o(STACK)
 
     Global Symbols
 
@@ -1031,189 +1010,176 @@ Image Symbol Table
     _main_init                               0x080000c9   Thumb Code     0  entry9a.o(.ARM.Collect$$$$0000000B)
     __rt_final_cpp                           0x080000d1   Thumb Code     0  entry10a.o(.ARM.Collect$$$$0000000D)
     __rt_final_exit                          0x080000d1   Thumb Code     0  entry11a.o(.ARM.Collect$$$$0000000F)
-    main                                     0x080000d5   Thumb Code  1698  main.o(.text)
-    TIM17_IRQHandler                         0x080007b1   Thumb Code   234  blinker.o(.text)
-    set_blink_style                          0x0800089b   Thumb Code    26  blinker.o(.text)
-    init_blinker                             0x080008b5   Thumb Code   120  blinker.o(.text)
-    I2C_WrReg                                0x08000945   Thumb Code   232  mpu6050.o(.text)
-    ReadMPU                                  0x08000a2d   Thumb Code   758  mpu6050.o(.text)
-    init_MPU6050                             0x08000d23   Thumb Code   188  mpu6050.o(.text)
-    init_ADC                                 0x08000df1   Thumb Code   126  adc.o(.text)
-    ADC1_COMP_IRQHandler                     0x08000e6f   Thumb Code    42  adc.o(.text)
-    micros                                   0x08000ea5   Thumb Code    14  timer.o(.text)
-    millis                                   0x08000eb3   Thumb Code    18  timer.o(.text)
-    delay_micros                             0x08000ec5   Thumb Code    24  timer.o(.text)
-    TIM3_IRQHandler                          0x08000edd   Thumb Code    32  timer.o(.text)
-    init_timer                               0x08000efd   Thumb Code    74  timer.o(.text)
-    NMI_Handler                              0x08000f55   Thumb Code     2  stm32f0xx_it.o(.text)
-    HardFault_Handler                        0x08000f57   Thumb Code     4  stm32f0xx_it.o(.text)
-    SVC_Handler                              0x08000f5b   Thumb Code     2  stm32f0xx_it.o(.text)
-    PendSV_Handler                           0x08000f5d   Thumb Code     2  stm32f0xx_it.o(.text)
-    SystemInit                               0x08000fd7   Thumb Code   110  system_stm32f0xx.o(.text)
-    nrfReadReg                               0x0800108f   Thumb Code    62  nrf24.o(.text)
-    nrfWriteReg                              0x080010cd   Thumb Code    68  nrf24.o(.text)
-    nrfWrite1Reg                             0x08001111   Thumb Code    16  nrf24.o(.text)
-    nrfRead1Reg                              0x08001121   Thumb Code    20  nrf24.o(.text)
-    nrfNop                                   0x08001135   Thumb Code    38  nrf24.o(.text)
-    nrfFlushRx                               0x0800115b   Thumb Code    38  nrf24.o(.text)
-    nrfFlushTx                               0x08001181   Thumb Code    38  nrf24.o(.text)
-    nrfRxLength                              0x080011a7   Thumb Code    44  nrf24.o(.text)
-    nrfActivate                              0x080011d3   Thumb Code    44  nrf24.o(.text)
-    nrfActivateBK2423                        0x080011ff   Thumb Code    44  nrf24.o(.text)
-    nrfWriteAck                              0x0800122b   Thumb Code    68  nrf24.o(.text)
-    nrfReadRX                                0x0800126f   Thumb Code    58  nrf24.o(.text)
-    nrfSendTX                                0x080012a9   Thumb Code    58  nrf24.o(.text)
-    nrfIsr                                   0x080012e3   Thumb Code    18  nrf24.o(.text)
-    nrfSetInterruptCallback                  0x080012f5   Thumb Code     6  nrf24.o(.text)
-    nrfSetChannel                            0x080012fb   Thumb Code    18  nrf24.o(.text)
-    nrfSetDatarate                           0x0800130d   Thumb Code    52  nrf24.o(.text)
-    nrfSetAddress                            0x08001341   Thumb Code    30  nrf24.o(.text)
-    nrfSetEnable                             0x0800135f   Thumb Code    32  nrf24.o(.text)
-    nrfGetStatus                             0x0800137f   Thumb Code     8  nrf24.o(.text)
-    nrfInit                                  0x08001387   Thumb Code   258  nrf24.o(.text)
-    nrfTest                                  0x08001489   Thumb Code     6  nrf24.o(.text)
-    init_motorpwm                            0x08001499   Thumb Code   194  motorpwm.o(.text)
-    mixer                                    0x0800155b   Thumb Code   114  motorpwm.o(.text)
-    set_motorpwm                             0x080015cd   Thumb Code    78  motorpwm.o(.text)
-    init_rf                                  0x08001621   Thumb Code   316  rfproto.o(.text)
-    rx_rf                                    0x0800175d   Thumb Code   456  rfproto.o(.text)
-    bind_rf                                  0x08001925   Thumb Code   716  rfproto.o(.text)
-    invSqrt                                  0x08001c09   Thumb Code    68  imu.o(.text)
-    update_imu                               0x08001c4d   Thumb Code  1038  imu.o(.text)
-    ADC_Init                                 0x08002065   Thumb Code    40  stm32f0xx_adc.o(.text)
-    ADC_Cmd                                  0x0800208d   Thumb Code    24  stm32f0xx_adc.o(.text)
-    ADC_ChannelConfig                        0x080020a5   Thumb Code    24  stm32f0xx_adc.o(.text)
-    ADC_GetCalibrationFactor                 0x080020bd   Thumb Code    60  stm32f0xx_adc.o(.text)
-    ADC_StartOfConversion                    0x080020f9   Thumb Code    10  stm32f0xx_adc.o(.text)
-    ADC_ITConfig                             0x08002103   Thumb Code    20  stm32f0xx_adc.o(.text)
-    ADC_GetFlagStatus                        0x08002117   Thumb Code    48  stm32f0xx_adc.o(.text)
-    GPIO_Init                                0x0800214d   Thumb Code   144  stm32f0xx_gpio.o(.text)
-    GPIO_StructInit                          0x080021dd   Thumb Code    20  stm32f0xx_gpio.o(.text)
-    GPIO_SetBits                             0x080021f1   Thumb Code     4  stm32f0xx_gpio.o(.text)
-    GPIO_ResetBits                           0x080021f5   Thumb Code     4  stm32f0xx_gpio.o(.text)
-    GPIO_WriteBit                            0x080021f9   Thumb Code    12  stm32f0xx_gpio.o(.text)
-    GPIO_PinAFConfig                         0x08002205   Thumb Code    68  stm32f0xx_gpio.o(.text)
-    I2C_Init                                 0x0800224d   Thumb Code    98  stm32f0xx_i2c.o(.text)
-    I2C_Cmd                                  0x080022af   Thumb Code    24  stm32f0xx_i2c.o(.text)
-    I2C_TransferHandling                     0x080022c7   Thumb Code    38  stm32f0xx_i2c.o(.text)
-    I2C_SendData                             0x080022ed   Thumb Code     4  stm32f0xx_i2c.o(.text)
-    I2C_ReceiveData                          0x080022f1   Thumb Code     8  stm32f0xx_i2c.o(.text)
-    I2C_GetFlagStatus                        0x080022f9   Thumb Code    28  stm32f0xx_i2c.o(.text)
-    I2C_ClearFlag                            0x08002315   Thumb Code     4  stm32f0xx_i2c.o(.text)
-    RCC_AHBPeriphClockCmd                    0x08002325   Thumb Code    28  stm32f0xx_rcc.o(.text)
-    RCC_APB2PeriphClockCmd                   0x08002341   Thumb Code    28  stm32f0xx_rcc.o(.text)
-    RCC_APB1PeriphClockCmd                   0x0800235d   Thumb Code    28  stm32f0xx_rcc.o(.text)
-    RCC_APB2PeriphResetCmd                   0x08002379   Thumb Code    28  stm32f0xx_rcc.o(.text)
-    RCC_APB1PeriphResetCmd                   0x08002395   Thumb Code    28  stm32f0xx_rcc.o(.text)
-    SPI_Init                                 0x080023b5   Thumb Code    76  stm32f0xx_spi.o(.text)
-    SPI_Cmd                                  0x08002401   Thumb Code    26  stm32f0xx_spi.o(.text)
-    SPI_RxFIFOThresholdConfig                0x0800241b   Thumb Code    16  stm32f0xx_spi.o(.text)
-    SPI_SendData8                            0x0800242b   Thumb Code    10  stm32f0xx_spi.o(.text)
-    SPI_ReceiveData8                         0x08002435   Thumb Code    12  stm32f0xx_spi.o(.text)
-    SPI_I2S_GetFlagStatus                    0x08002441   Thumb Code    20  stm32f0xx_spi.o(.text)
-    TIM_DeInit                               0x08002465   Thumb Code   228  stm32f0xx_tim.o(.text)
-    TIM_TimeBaseInit                         0x08002549   Thumb Code    90  stm32f0xx_tim.o(.text)
-    TIM_Cmd                                  0x080025a3   Thumb Code    26  stm32f0xx_tim.o(.text)
-    TIM_CtrlPWMOutputs                       0x080025bd   Thumb Code    34  stm32f0xx_tim.o(.text)
-    TIM_OC1Init                              0x080025df   Thumb Code   122  stm32f0xx_tim.o(.text)
-    TIM_OC2Init                              0x08002659   Thumb Code   144  stm32f0xx_tim.o(.text)
-    TIM_OC3Init                              0x080026e9   Thumb Code   124  stm32f0xx_tim.o(.text)
-    TIM_OC4Init                              0x08002765   Thumb Code    88  stm32f0xx_tim.o(.text)
-    TIM_ITConfig                             0x0800290b   Thumb Code    20  stm32f0xx_tim.o(.text)
-    NVIC_Init                                0x08002925   Thumb Code   106  stm32f0xx_misc.o(.text)
-    Reset_Handler                            0x08002995   Thumb Code    38  startup_stm32f0xx_mdk_arm.o(.text)
-    SysTick_Handler                          0x080029c3   Thumb Code     2  startup_stm32f0xx_mdk_arm.o(.text)
-    CEC_IRQHandler                           0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    DMA1_Channel1_IRQHandler                 0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    DMA1_Channel2_3_IRQHandler               0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    DMA1_Channel4_5_IRQHandler               0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    EXTI0_1_IRQHandler                       0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    EXTI2_3_IRQHandler                       0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    EXTI4_15_IRQHandler                      0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    FLASH_IRQHandler                         0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    I2C1_IRQHandler                          0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    I2C2_IRQHandler                          0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    PVD_IRQHandler                           0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    RCC_IRQHandler                           0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    RTC_IRQHandler                           0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    SPI1_IRQHandler                          0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    SPI2_IRQHandler                          0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    TIM14_IRQHandler                         0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    TIM15_IRQHandler                         0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    TIM16_IRQHandler                         0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    TIM1_BRK_UP_TRG_COM_IRQHandler           0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    TIM1_CC_IRQHandler                       0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    TIM2_IRQHandler                          0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    TIM6_DAC_IRQHandler                      0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    TS_IRQHandler                            0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    USART1_IRQHandler                        0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    USART2_IRQHandler                        0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    WWDG_IRQHandler                          0x080029c5   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
-    __aeabi_uidiv                            0x080029ed   Thumb Code     0  uidiv.o(.text)
-    __aeabi_uidivmod                         0x080029ed   Thumb Code    44  uidiv.o(.text)
-    __aeabi_idiv                             0x08002a19   Thumb Code     0  idiv.o(.text)
-    __aeabi_idivmod                          0x08002a19   Thumb Code    40  idiv.o(.text)
-    __aeabi_memcpy                           0x08002a41   Thumb Code    36  memcpya.o(.text)
-    __aeabi_memcpy4                          0x08002a41   Thumb Code     0  memcpya.o(.text)
-    __aeabi_memcpy8                          0x08002a41   Thumb Code     0  memcpya.o(.text)
-    __aeabi_fadd                             0x08002a65   Thumb Code   162  fadd.o(.text)
-    __aeabi_fsub                             0x08002b07   Thumb Code     8  fadd.o(.text)
-    __aeabi_frsub                            0x08002b0f   Thumb Code     8  fadd.o(.text)
-    __aeabi_fmul                             0x08002b17   Thumb Code   122  fmul.o(.text)
-    __aeabi_dmul                             0x08002b91   Thumb Code   202  dmul.o(.text)
-    __aeabi_i2f                              0x08002c61   Thumb Code    22  fflti.o(.text)
-    __aeabi_i2d                              0x08002c79   Thumb Code    34  dflti.o(.text)
-    __aeabi_f2iz                             0x08002ca1   Thumb Code    50  ffixi.o(.text)
-    __aeabi_f2d                              0x08002cd3   Thumb Code    40  f2d.o(.text)
-    __aeabi_d2f                              0x08002cfb   Thumb Code    56  d2f.o(.text)
-    __aeabi_cfcmpeq                          0x08002d35   Thumb Code     0  cfcmple.o(.text)
-    __aeabi_cfcmple                          0x08002d35   Thumb Code    20  cfcmple.o(.text)
-    __aeabi_cfrcmple                         0x08002d49   Thumb Code    20  cfrcmple.o(.text)
-    __I$use$fp                               0x08002d5d   Thumb Code     0  iusefp.o(.text)
-    _float_round                             0x08002d5d   Thumb Code    16  fepilogue.o(.text)
-    _float_epilogue                          0x08002d6d   Thumb Code   114  fepilogue.o(.text)
-    __aeabi_fdiv                             0x08002ddf   Thumb Code   124  fdiv.o(.text)
-    __ARM_scalbnf                            0x08002e5b   Thumb Code    24  fscalb.o(.text)
-    scalbnf                                  0x08002e5b   Thumb Code     0  fscalb.o(.text)
-    _double_round                            0x08002e73   Thumb Code    26  depilogue.o(.text)
-    _double_epilogue                         0x08002e8d   Thumb Code   164  depilogue.o(.text)
-    __scatterload                            0x08002f31   Thumb Code    28  init.o(.text)
-    __scatterload_rt2                        0x08002f31   Thumb Code     0  init.o(.text)
-    __aeabi_llsl                             0x08002f55   Thumb Code    32  llshl.o(.text)
-    _ll_shift_l                              0x08002f55   Thumb Code     0  llshl.o(.text)
-    __aeabi_llsr                             0x08002f75   Thumb Code    34  llushr.o(.text)
-    _ll_ushift_r                             0x08002f75   Thumb Code     0  llushr.o(.text)
-    _fsqrt                                   0x08002f97   Thumb Code    88  fsqrt.o(.text)
-    __ARM_clz                                0x08002fef   Thumb Code    46  depilogue.o(i.__ARM_clz)
-    __ARM_common_switch8                     0x0800301d   Thumb Code    28  main.o(i.__ARM_common_switch8)
-    __ARM_fpclassifyf                        0x08003039   Thumb Code    34  fpclassifyf.o(i.__ARM_fpclassifyf)
-    __mathlib_flt_infnan                     0x0800305b   Thumb Code    10  funder.o(i.__mathlib_flt_infnan)
-    __mathlib_flt_infnan2                    0x08003065   Thumb Code     8  funder.o(i.__mathlib_flt_infnan2)
-    __mathlib_flt_invalid                    0x0800306d   Thumb Code    12  funder.o(i.__mathlib_flt_invalid)
-    __mathlib_flt_underflow                  0x08003079   Thumb Code    14  funder.o(i.__mathlib_flt_underflow)
-    __scatterload_copy                       0x08003087   Thumb Code    14  handlers.o(i.__scatterload_copy)
-    __scatterload_null                       0x08003095   Thumb Code     2  handlers.o(i.__scatterload_null)
-    __scatterload_zeroinit                   0x08003097   Thumb Code    14  handlers.o(i.__scatterload_zeroinit)
-    __set_errno                              0x080030a5   Thumb Code     6  errno.o(i.__set_errno)
-    asinf                                    0x080030b1   Thumb Code   242  asinf.o(i.asinf)
-    atan2f                                   0x080031c9   Thumb Code   526  atan2f.o(i.atan2f)
-    sqrtf                                    0x08003425   Thumb Code    44  sqrtf.o(i.sqrtf)
-    rf_addr_bind                             0x08003470   Data           5  rfproto.o(.constdata)
-    Region$$Table$$Base                      0x08003488   Number         0  anon$$obj.o(Region$$Table)
-    Region$$Table$$Limit                     0x080034a8   Number         0  anon$$obj.o(Region$$Table)
+    main                                     0x080000d5   Thumb Code  1488  main.o(.text)
+    TIM17_IRQHandler                         0x080006c5   Thumb Code   234  blinker.o(.text)
+    set_blink_style                          0x080007af   Thumb Code    26  blinker.o(.text)
+    init_blinker                             0x080007c9   Thumb Code   120  blinker.o(.text)
+    I2C_WrReg                                0x08000859   Thumb Code   232  mpu6050.o(.text)
+    ReadMPU                                  0x08000941   Thumb Code   816  mpu6050.o(.text)
+    init_MPU6050                             0x08000c71   Thumb Code   154  mpu6050.o(.text)
+    init_ADC                                 0x08000d1d   Thumb Code   126  adc.o(.text)
+    ADC1_COMP_IRQHandler                     0x08000d9b   Thumb Code    42  adc.o(.text)
+    micros                                   0x08000dd1   Thumb Code    14  timer.o(.text)
+    millis                                   0x08000ddf   Thumb Code    18  timer.o(.text)
+    delay_micros                             0x08000df1   Thumb Code    24  timer.o(.text)
+    TIM3_IRQHandler                          0x08000e09   Thumb Code    32  timer.o(.text)
+    init_timer                               0x08000e29   Thumb Code    74  timer.o(.text)
+    NMI_Handler                              0x08000e81   Thumb Code     2  stm32f0xx_it.o(.text)
+    HardFault_Handler                        0x08000e83   Thumb Code     4  stm32f0xx_it.o(.text)
+    SVC_Handler                              0x08000e87   Thumb Code     2  stm32f0xx_it.o(.text)
+    PendSV_Handler                           0x08000e89   Thumb Code     2  stm32f0xx_it.o(.text)
+    SystemInit                               0x08000f03   Thumb Code   110  system_stm32f0xx.o(.text)
+    nrfReadReg                               0x08000fbb   Thumb Code    62  nrf24.o(.text)
+    nrfWriteReg                              0x08000ff9   Thumb Code    68  nrf24.o(.text)
+    nrfWrite1Reg                             0x0800103d   Thumb Code    16  nrf24.o(.text)
+    nrfRead1Reg                              0x0800104d   Thumb Code    20  nrf24.o(.text)
+    nrfNop                                   0x08001061   Thumb Code    38  nrf24.o(.text)
+    nrfFlushRx                               0x08001087   Thumb Code    38  nrf24.o(.text)
+    nrfFlushTx                               0x080010ad   Thumb Code    38  nrf24.o(.text)
+    nrfRxLength                              0x080010d3   Thumb Code    44  nrf24.o(.text)
+    nrfActivate                              0x080010ff   Thumb Code    44  nrf24.o(.text)
+    nrfActivateBK2423                        0x0800112b   Thumb Code    44  nrf24.o(.text)
+    nrfWriteAck                              0x08001157   Thumb Code    68  nrf24.o(.text)
+    nrfReadRX                                0x0800119b   Thumb Code    58  nrf24.o(.text)
+    nrfSendTX                                0x080011d5   Thumb Code    58  nrf24.o(.text)
+    nrfIsr                                   0x0800120f   Thumb Code    18  nrf24.o(.text)
+    nrfSetInterruptCallback                  0x08001221   Thumb Code     6  nrf24.o(.text)
+    nrfSetChannel                            0x08001227   Thumb Code    18  nrf24.o(.text)
+    nrfSetDatarate                           0x08001239   Thumb Code    52  nrf24.o(.text)
+    nrfSetAddress                            0x0800126d   Thumb Code    30  nrf24.o(.text)
+    nrfSetEnable                             0x0800128b   Thumb Code    32  nrf24.o(.text)
+    nrfGetStatus                             0x080012ab   Thumb Code     8  nrf24.o(.text)
+    nrfInit                                  0x080012b3   Thumb Code   258  nrf24.o(.text)
+    nrfTest                                  0x080013b5   Thumb Code     6  nrf24.o(.text)
+    init_motorpwm                            0x080013c5   Thumb Code   194  motorpwm.o(.text)
+    mixer                                    0x08001487   Thumb Code   114  motorpwm.o(.text)
+    set_motorpwm                             0x080014f9   Thumb Code    78  motorpwm.o(.text)
+    init_rf                                  0x0800154d   Thumb Code   316  rfproto.o(.text)
+    rx_rf                                    0x08001689   Thumb Code   464  rfproto.o(.text)
+    bind_rf                                  0x08001859   Thumb Code   718  rfproto.o(.text)
+    invSqrt                                  0x08001b41   Thumb Code    68  imu.o(.text)
+    update_imu                               0x08001b85   Thumb Code  1038  imu.o(.text)
+    ADC_Init                                 0x08001f9d   Thumb Code    40  stm32f0xx_adc.o(.text)
+    ADC_Cmd                                  0x08001fc5   Thumb Code    24  stm32f0xx_adc.o(.text)
+    ADC_ChannelConfig                        0x08001fdd   Thumb Code    24  stm32f0xx_adc.o(.text)
+    ADC_GetCalibrationFactor                 0x08001ff5   Thumb Code    60  stm32f0xx_adc.o(.text)
+    ADC_StartOfConversion                    0x08002031   Thumb Code    10  stm32f0xx_adc.o(.text)
+    ADC_ITConfig                             0x0800203b   Thumb Code    20  stm32f0xx_adc.o(.text)
+    ADC_GetFlagStatus                        0x0800204f   Thumb Code    48  stm32f0xx_adc.o(.text)
+    GPIO_Init                                0x08002085   Thumb Code   144  stm32f0xx_gpio.o(.text)
+    GPIO_StructInit                          0x08002115   Thumb Code    20  stm32f0xx_gpio.o(.text)
+    GPIO_SetBits                             0x08002129   Thumb Code     4  stm32f0xx_gpio.o(.text)
+    GPIO_ResetBits                           0x0800212d   Thumb Code     4  stm32f0xx_gpio.o(.text)
+    GPIO_WriteBit                            0x08002131   Thumb Code    12  stm32f0xx_gpio.o(.text)
+    GPIO_PinAFConfig                         0x0800213d   Thumb Code    68  stm32f0xx_gpio.o(.text)
+    I2C_Init                                 0x08002185   Thumb Code    98  stm32f0xx_i2c.o(.text)
+    I2C_Cmd                                  0x080021e7   Thumb Code    24  stm32f0xx_i2c.o(.text)
+    I2C_TransferHandling                     0x080021ff   Thumb Code    38  stm32f0xx_i2c.o(.text)
+    I2C_SendData                             0x08002225   Thumb Code     4  stm32f0xx_i2c.o(.text)
+    I2C_ReceiveData                          0x08002229   Thumb Code     8  stm32f0xx_i2c.o(.text)
+    I2C_GetFlagStatus                        0x08002231   Thumb Code    28  stm32f0xx_i2c.o(.text)
+    I2C_ClearFlag                            0x0800224d   Thumb Code     4  stm32f0xx_i2c.o(.text)
+    RCC_AHBPeriphClockCmd                    0x0800225d   Thumb Code    28  stm32f0xx_rcc.o(.text)
+    RCC_APB2PeriphClockCmd                   0x08002279   Thumb Code    28  stm32f0xx_rcc.o(.text)
+    RCC_APB1PeriphClockCmd                   0x08002295   Thumb Code    28  stm32f0xx_rcc.o(.text)
+    RCC_APB2PeriphResetCmd                   0x080022b1   Thumb Code    28  stm32f0xx_rcc.o(.text)
+    RCC_APB1PeriphResetCmd                   0x080022cd   Thumb Code    28  stm32f0xx_rcc.o(.text)
+    SPI_Init                                 0x080022ed   Thumb Code    76  stm32f0xx_spi.o(.text)
+    SPI_Cmd                                  0x08002339   Thumb Code    26  stm32f0xx_spi.o(.text)
+    SPI_RxFIFOThresholdConfig                0x08002353   Thumb Code    16  stm32f0xx_spi.o(.text)
+    SPI_SendData8                            0x08002363   Thumb Code    10  stm32f0xx_spi.o(.text)
+    SPI_ReceiveData8                         0x0800236d   Thumb Code    12  stm32f0xx_spi.o(.text)
+    SPI_I2S_GetFlagStatus                    0x08002379   Thumb Code    20  stm32f0xx_spi.o(.text)
+    TIM_DeInit                               0x0800239d   Thumb Code   228  stm32f0xx_tim.o(.text)
+    TIM_TimeBaseInit                         0x08002481   Thumb Code    90  stm32f0xx_tim.o(.text)
+    TIM_Cmd                                  0x080024db   Thumb Code    26  stm32f0xx_tim.o(.text)
+    TIM_CtrlPWMOutputs                       0x080024f5   Thumb Code    34  stm32f0xx_tim.o(.text)
+    TIM_OC1Init                              0x08002517   Thumb Code   122  stm32f0xx_tim.o(.text)
+    TIM_OC2Init                              0x08002591   Thumb Code   144  stm32f0xx_tim.o(.text)
+    TIM_OC3Init                              0x08002621   Thumb Code   124  stm32f0xx_tim.o(.text)
+    TIM_OC4Init                              0x0800269d   Thumb Code    88  stm32f0xx_tim.o(.text)
+    TIM_ITConfig                             0x08002843   Thumb Code    20  stm32f0xx_tim.o(.text)
+    NVIC_Init                                0x0800285d   Thumb Code   106  stm32f0xx_misc.o(.text)
+    Reset_Handler                            0x080028cd   Thumb Code    38  startup_stm32f0xx_mdk_arm.o(.text)
+    SysTick_Handler                          0x080028fb   Thumb Code     2  startup_stm32f0xx_mdk_arm.o(.text)
+    CEC_IRQHandler                           0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    DMA1_Channel1_IRQHandler                 0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    DMA1_Channel2_3_IRQHandler               0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    DMA1_Channel4_5_IRQHandler               0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    EXTI0_1_IRQHandler                       0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    EXTI2_3_IRQHandler                       0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    EXTI4_15_IRQHandler                      0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    FLASH_IRQHandler                         0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    I2C1_IRQHandler                          0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    I2C2_IRQHandler                          0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    PVD_IRQHandler                           0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    RCC_IRQHandler                           0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    RTC_IRQHandler                           0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    SPI1_IRQHandler                          0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    SPI2_IRQHandler                          0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    TIM14_IRQHandler                         0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    TIM15_IRQHandler                         0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    TIM16_IRQHandler                         0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    TIM1_BRK_UP_TRG_COM_IRQHandler           0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    TIM1_CC_IRQHandler                       0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    TIM2_IRQHandler                          0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    TIM6_DAC_IRQHandler                      0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    TS_IRQHandler                            0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    USART1_IRQHandler                        0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    USART2_IRQHandler                        0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    WWDG_IRQHandler                          0x080028fd   Thumb Code     0  startup_stm32f0xx_mdk_arm.o(.text)
+    __aeabi_uidiv                            0x08002925   Thumb Code     0  uidiv.o(.text)
+    __aeabi_uidivmod                         0x08002925   Thumb Code    44  uidiv.o(.text)
+    __aeabi_idiv                             0x08002951   Thumb Code     0  idiv.o(.text)
+    __aeabi_idivmod                          0x08002951   Thumb Code    40  idiv.o(.text)
+    __aeabi_memcpy                           0x08002979   Thumb Code    36  memcpya.o(.text)
+    __aeabi_memcpy4                          0x08002979   Thumb Code     0  memcpya.o(.text)
+    __aeabi_memcpy8                          0x08002979   Thumb Code     0  memcpya.o(.text)
+    __aeabi_fadd                             0x0800299d   Thumb Code   162  fadd.o(.text)
+    __aeabi_fsub                             0x08002a3f   Thumb Code     8  fadd.o(.text)
+    __aeabi_frsub                            0x08002a47   Thumb Code     8  fadd.o(.text)
+    __aeabi_fmul                             0x08002a4f   Thumb Code   122  fmul.o(.text)
+    __aeabi_i2f                              0x08002ac9   Thumb Code    22  fflti.o(.text)
+    __aeabi_f2iz                             0x08002adf   Thumb Code    50  ffixi.o(.text)
+    __aeabi_cfcmpeq                          0x08002b11   Thumb Code     0  cfcmple.o(.text)
+    __aeabi_cfcmple                          0x08002b11   Thumb Code    20  cfcmple.o(.text)
+    __aeabi_cfrcmple                         0x08002b25   Thumb Code    20  cfrcmple.o(.text)
+    __I$use$fp                               0x08002b39   Thumb Code     0  iusefp.o(.text)
+    _float_round                             0x08002b39   Thumb Code    16  fepilogue.o(.text)
+    _float_epilogue                          0x08002b49   Thumb Code   114  fepilogue.o(.text)
+    __aeabi_fdiv                             0x08002bbb   Thumb Code   124  fdiv.o(.text)
+    __ARM_scalbnf                            0x08002c37   Thumb Code    24  fscalb.o(.text)
+    scalbnf                                  0x08002c37   Thumb Code     0  fscalb.o(.text)
+    __scatterload                            0x08002c51   Thumb Code    28  init.o(.text)
+    __scatterload_rt2                        0x08002c51   Thumb Code     0  init.o(.text)
+    _fsqrt                                   0x08002c75   Thumb Code    88  fsqrt.o(.text)
+    __ARM_common_switch8                     0x08002ccd   Thumb Code    28  main.o(i.__ARM_common_switch8)
+    __ARM_fpclassifyf                        0x08002ce9   Thumb Code    34  fpclassifyf.o(i.__ARM_fpclassifyf)
+    __mathlib_flt_infnan                     0x08002d0b   Thumb Code    10  funder.o(i.__mathlib_flt_infnan)
+    __mathlib_flt_infnan2                    0x08002d15   Thumb Code     8  funder.o(i.__mathlib_flt_infnan2)
+    __mathlib_flt_invalid                    0x08002d1d   Thumb Code    12  funder.o(i.__mathlib_flt_invalid)
+    __mathlib_flt_underflow                  0x08002d29   Thumb Code    14  funder.o(i.__mathlib_flt_underflow)
+    __scatterload_copy                       0x08002d37   Thumb Code    14  handlers.o(i.__scatterload_copy)
+    __scatterload_null                       0x08002d45   Thumb Code     2  handlers.o(i.__scatterload_null)
+    __scatterload_zeroinit                   0x08002d47   Thumb Code    14  handlers.o(i.__scatterload_zeroinit)
+    __set_errno                              0x08002d55   Thumb Code     6  errno.o(i.__set_errno)
+    asinf                                    0x08002d61   Thumb Code   242  asinf.o(i.asinf)
+    atan2f                                   0x08002e79   Thumb Code   526  atan2f.o(i.atan2f)
+    sqrtf                                    0x080030d5   Thumb Code    44  sqrtf.o(i.sqrtf)
+    rf_addr_bind                             0x08003120   Data           5  rfproto.o(.constdata)
+    Region$$Table$$Base                      0x08003138   Number         0  anon$$obj.o(Region$$Table)
+    Region$$Table$$Limit                     0x08003158   Number         0  anon$$obj.o(Region$$Table)
     LiPoVolt                                 0x20000000   Data           2  main.o(.data)
-    failsafe                                 0x20000002   Data           1  main.o(.data)
-    mode                                     0x20000003   Data           1  main.o(.data)
-    twoKp                                    0x2000003c   Data           4  imu.o(.data)
-    twoKi                                    0x20000040   Data           4  imu.o(.data)
-    q0                                       0x20000044   Data           4  imu.o(.data)
-    q1                                       0x20000048   Data           4  imu.o(.data)
-    q2                                       0x2000004c   Data           4  imu.o(.data)
-    q3                                       0x20000050   Data           4  imu.o(.data)
-    integralFBx                              0x20000054   Data           4  imu.o(.data)
-    integralFBy                              0x20000058   Data           4  imu.o(.data)
-    integralFBz                              0x2000005c   Data           4  imu.o(.data)
-    __initial_sp                             0x20000490   Data           0  startup_stm32f0xx_mdk_arm.o(STACK)
+    twoKp                                    0x2000004c   Data           4  imu.o(.data)
+    twoKi                                    0x20000050   Data           4  imu.o(.data)
+    q0                                       0x20000054   Data           4  imu.o(.data)
+    q1                                       0x20000058   Data           4  imu.o(.data)
+    q2                                       0x2000005c   Data           4  imu.o(.data)
+    q3                                       0x20000060   Data           4  imu.o(.data)
+    integralFBx                              0x20000064   Data           4  imu.o(.data)
+    integralFBy                              0x20000068   Data           4  imu.o(.data)
+    integralFBz                              0x2000006c   Data           4  imu.o(.data)
+    __initial_sp                             0x200004b0   Data           0  startup_stm32f0xx_mdk_arm.o(STACK)
 
 
 
@@ -1221,112 +1187,105 @@ Image Symbol Table
 
 Memory Map of the image
 
-  Image Entry point : 0x08002995
+  Image Entry point : 0x080028cd
 
-  Load Region LR_1 (Base: 0x08000000, Size: 0x0000350c, Max: 0xffffffff, ABSOLUTE)
+  Load Region LR_1 (Base: 0x08000000, Size: 0x000031cc, Max: 0xffffffff, ABSOLUTE)
 
-    Execution Region ER_RO (Base: 0x08000000, Size: 0x000034a8, Max: 0xffffffff, ABSOLUTE)
+    Execution Region ER_RO (Base: 0x08000000, Size: 0x00003158, Max: 0xffffffff, ABSOLUTE)
 
     Base Addr    Size         Type   Attr      Idx    E Section Name        Object
 
     0x08000000   0x000000c0   Data   RO         3453    RESET               startup_stm32f0xx_mdk_arm.o
     0x080000c0   0x00000000   Code   RO         3474  * .ARM.Collect$$$$00000000  mc_p.l(entry.o)
-    0x080000c0   0x00000004   Code   RO         3529    .ARM.Collect$$$$00000001  mc_p.l(entry2.o)
-    0x080000c4   0x00000004   Code   RO         3532    .ARM.Collect$$$$00000004  mc_p.l(entry5.o)
-    0x080000c8   0x00000000   Code   RO         3534    .ARM.Collect$$$$00000008  mc_p.l(entry7b.o)
-    0x080000c8   0x00000000   Code   RO         3536    .ARM.Collect$$$$0000000A  mc_p.l(entry8b.o)
-    0x080000c8   0x00000008   Code   RO         3537    .ARM.Collect$$$$0000000B  mc_p.l(entry9a.o)
-    0x080000d0   0x00000000   Code   RO         3539    .ARM.Collect$$$$0000000D  mc_p.l(entry10a.o)
-    0x080000d0   0x00000000   Code   RO         3541    .ARM.Collect$$$$0000000F  mc_p.l(entry11a.o)
-    0x080000d0   0x00000004   Code   RO         3530    .ARM.Collect$$$$00002712  mc_p.l(entry2.o)
-    0x080000d4   0x000006dc   Code   RO            3    .text               main.o
-    0x080007b0   0x00000194   Code   RO          141    .text               blinker.o
-    0x08000944   0x000004ac   Code   RO          167    .text               mpu6050.o
-    0x08000df0   0x000000b4   Code   RO          189    .text               adc.o
-    0x08000ea4   0x000000b0   Code   RO          209    .text               timer.o
-    0x08000f54   0x0000000a   Code   RO          231    .text               stm32f0xx_it.o
-    0x08000f5e   0x00000002   PAD
-    0x08000f60   0x000000f4   Code   RO          272    .text               system_stm32f0xx.o
-    0x08001054   0x00000444   Code   RO          304    .text               nrf24.o
-    0x08001498   0x00000188   Code   RO          326    .text               motorpwm.o
-    0x08001620   0x000005e8   Code   RO          346    .text               rfproto.o
-    0x08001c08   0x0000045c   Code   RO          369    .text               imu.o
-    0x08002064   0x000000e8   Code   RO          390    .text               stm32f0xx_adc.o
-    0x0800214c   0x00000100   Code   RO         1335    .text               stm32f0xx_gpio.o
-    0x0800224c   0x000000d8   Code   RO         1397    .text               stm32f0xx_i2c.o
-    0x08002324   0x00000090   Code   RO         1787    .text               stm32f0xx_rcc.o
-    0x080023b4   0x000000b0   Code   RO         2321    .text               stm32f0xx_spi.o
-    0x08002464   0x000004c0   Code   RO         2489    .text               stm32f0xx_tim.o
-    0x08002924   0x00000070   Code   RO         3359    .text               stm32f0xx_misc.o
-    0x08002994   0x00000058   Code   RO         3454  * .text               startup_stm32f0xx_mdk_arm.o
-    0x080029ec   0x0000002c   Code   RO         3477    .text               mc_p.l(uidiv.o)
-    0x08002a18   0x00000028   Code   RO         3479    .text               mc_p.l(idiv.o)
-    0x08002a40   0x00000024   Code   RO         3481    .text               mc_p.l(memcpya.o)
-    0x08002a64   0x000000b2   Code   RO         3485    .text               mf_p.l(fadd.o)
-    0x08002b16   0x0000007a   Code   RO         3487    .text               mf_p.l(fmul.o)
-    0x08002b90   0x000000d0   Code   RO         3489    .text               mf_p.l(dmul.o)
-    0x08002c60   0x00000016   Code   RO         3491    .text               mf_p.l(fflti.o)
-    0x08002c76   0x00000002   PAD
-    0x08002c78   0x00000028   Code   RO         3493    .text               mf_p.l(dflti.o)
-    0x08002ca0   0x00000032   Code   RO         3495    .text               mf_p.l(ffixi.o)
-    0x08002cd2   0x00000028   Code   RO         3497    .text               mf_p.l(f2d.o)
-    0x08002cfa   0x00000038   Code   RO         3499    .text               mf_p.l(d2f.o)
-    0x08002d32   0x00000002   PAD
-    0x08002d34   0x00000014   Code   RO         3501    .text               mf_p.l(cfcmple.o)
-    0x08002d48   0x00000014   Code   RO         3503    .text               mf_p.l(cfrcmple.o)
-    0x08002d5c   0x00000000   Code   RO         3550    .text               mc_p.l(iusefp.o)
-    0x08002d5c   0x00000082   Code   RO         3551    .text               mf_p.l(fepilogue.o)
-    0x08002dde   0x0000007c   Code   RO         3553    .text               mf_p.l(fdiv.o)
-    0x08002e5a   0x00000018   Code   RO         3555    .text               mf_p.l(fscalb.o)
-    0x08002e72   0x000000be   Code   RO         3557    .text               mf_p.l(depilogue.o)
-    0x08002f30   0x00000024   Code   RO         3561    .text               mc_p.l(init.o)
-    0x08002f54   0x00000020   Code   RO         3563    .text               mc_p.l(llshl.o)
-    0x08002f74   0x00000022   Code   RO         3565    .text               mc_p.l(llushr.o)
-    0x08002f96   0x00000058   Code   RO         3567    .text               mf_p.l(fsqrt.o)
-    0x08002fee   0x0000002e   Code   RO         3559    i.__ARM_clz         mf_p.l(depilogue.o)
-    0x0800301c   0x0000001c   Code   RO           23    i.__ARM_common_switch8  main.o
-    0x08003038   0x00000022   Code   RO         3505    i.__ARM_fpclassifyf  m_ps.l(fpclassifyf.o)
-    0x0800305a   0x0000000a   Code   RO         3508    i.__mathlib_flt_infnan  m_ps.l(funder.o)
-    0x08003064   0x00000008   Code   RO         3509    i.__mathlib_flt_infnan2  m_ps.l(funder.o)
-    0x0800306c   0x0000000c   Code   RO         3510    i.__mathlib_flt_invalid  m_ps.l(funder.o)
-    0x08003078   0x0000000e   Code   RO         3513    i.__mathlib_flt_underflow  m_ps.l(funder.o)
-    0x08003086   0x0000000e   Code   RO         3571    i.__scatterload_copy  mc_p.l(handlers.o)
-    0x08003094   0x00000002   Code   RO         3572    i.__scatterload_null  mc_p.l(handlers.o)
-    0x08003096   0x0000000e   Code   RO         3573    i.__scatterload_zeroinit  mc_p.l(handlers.o)
-    0x080030a4   0x0000000c   Code   RO         3545    i.__set_errno       mc_p.l(errno.o)
-    0x080030b0   0x00000118   Code   RO         3459    i.asinf             m_ps.l(asinf.o)
-    0x080031c8   0x0000025c   Code   RO         3467    i.atan2f            m_ps.l(atan2f.o)
-    0x08003424   0x0000002c   Code   RO         3522    i.sqrtf             m_ps.l(sqrtf.o)
-    0x08003450   0x00000020   Data   RO            4    .constdata          main.o
-    0x08003470   0x00000016   Data   RO          348    .constdata          rfproto.o
-    0x08003486   0x00000002   PAD
-    0x08003488   0x00000020   Data   RO         3569    Region$$Table       anon$$obj.o
+    0x080000c0   0x00000004   Code   RO         3521    .ARM.Collect$$$$00000001  mc_p.l(entry2.o)
+    0x080000c4   0x00000004   Code   RO         3524    .ARM.Collect$$$$00000004  mc_p.l(entry5.o)
+    0x080000c8   0x00000000   Code   RO         3526    .ARM.Collect$$$$00000008  mc_p.l(entry7b.o)
+    0x080000c8   0x00000000   Code   RO         3528    .ARM.Collect$$$$0000000A  mc_p.l(entry8b.o)
+    0x080000c8   0x00000008   Code   RO         3529    .ARM.Collect$$$$0000000B  mc_p.l(entry9a.o)
+    0x080000d0   0x00000000   Code   RO         3531    .ARM.Collect$$$$0000000D  mc_p.l(entry10a.o)
+    0x080000d0   0x00000000   Code   RO         3533    .ARM.Collect$$$$0000000F  mc_p.l(entry11a.o)
+    0x080000d0   0x00000004   Code   RO         3522    .ARM.Collect$$$$00002712  mc_p.l(entry2.o)
+    0x080000d4   0x000005f0   Code   RO            3    .text               main.o
+    0x080006c4   0x00000194   Code   RO          141    .text               blinker.o
+    0x08000858   0x000004c4   Code   RO          167    .text               mpu6050.o
+    0x08000d1c   0x000000b4   Code   RO          189    .text               adc.o
+    0x08000dd0   0x000000b0   Code   RO          209    .text               timer.o
+    0x08000e80   0x0000000a   Code   RO          231    .text               stm32f0xx_it.o
+    0x08000e8a   0x00000002   PAD
+    0x08000e8c   0x000000f4   Code   RO          272    .text               system_stm32f0xx.o
+    0x08000f80   0x00000444   Code   RO          304    .text               nrf24.o
+    0x080013c4   0x00000188   Code   RO          326    .text               motorpwm.o
+    0x0800154c   0x000005f4   Code   RO          346    .text               rfproto.o
+    0x08001b40   0x0000045c   Code   RO          369    .text               imu.o
+    0x08001f9c   0x000000e8   Code   RO          390    .text               stm32f0xx_adc.o
+    0x08002084   0x00000100   Code   RO         1335    .text               stm32f0xx_gpio.o
+    0x08002184   0x000000d8   Code   RO         1397    .text               stm32f0xx_i2c.o
+    0x0800225c   0x00000090   Code   RO         1787    .text               stm32f0xx_rcc.o
+    0x080022ec   0x000000b0   Code   RO         2321    .text               stm32f0xx_spi.o
+    0x0800239c   0x000004c0   Code   RO         2489    .text               stm32f0xx_tim.o
+    0x0800285c   0x00000070   Code   RO         3359    .text               stm32f0xx_misc.o
+    0x080028cc   0x00000058   Code   RO         3454  * .text               startup_stm32f0xx_mdk_arm.o
+    0x08002924   0x0000002c   Code   RO         3477    .text               mc_p.l(uidiv.o)
+    0x08002950   0x00000028   Code   RO         3479    .text               mc_p.l(idiv.o)
+    0x08002978   0x00000024   Code   RO         3481    .text               mc_p.l(memcpya.o)
+    0x0800299c   0x000000b2   Code   RO         3485    .text               mf_p.l(fadd.o)
+    0x08002a4e   0x0000007a   Code   RO         3487    .text               mf_p.l(fmul.o)
+    0x08002ac8   0x00000016   Code   RO         3489    .text               mf_p.l(fflti.o)
+    0x08002ade   0x00000032   Code   RO         3491    .text               mf_p.l(ffixi.o)
+    0x08002b10   0x00000014   Code   RO         3493    .text               mf_p.l(cfcmple.o)
+    0x08002b24   0x00000014   Code   RO         3495    .text               mf_p.l(cfrcmple.o)
+    0x08002b38   0x00000000   Code   RO         3542    .text               mc_p.l(iusefp.o)
+    0x08002b38   0x00000082   Code   RO         3543    .text               mf_p.l(fepilogue.o)
+    0x08002bba   0x0000007c   Code   RO         3545    .text               mf_p.l(fdiv.o)
+    0x08002c36   0x00000018   Code   RO         3547    .text               mf_p.l(fscalb.o)
+    0x08002c4e   0x00000002   PAD
+    0x08002c50   0x00000024   Code   RO         3549    .text               mc_p.l(init.o)
+    0x08002c74   0x00000058   Code   RO         3551    .text               mf_p.l(fsqrt.o)
+    0x08002ccc   0x0000001c   Code   RO           24    i.__ARM_common_switch8  main.o
+    0x08002ce8   0x00000022   Code   RO         3497    i.__ARM_fpclassifyf  m_ps.l(fpclassifyf.o)
+    0x08002d0a   0x0000000a   Code   RO         3500    i.__mathlib_flt_infnan  m_ps.l(funder.o)
+    0x08002d14   0x00000008   Code   RO         3501    i.__mathlib_flt_infnan2  m_ps.l(funder.o)
+    0x08002d1c   0x0000000c   Code   RO         3502    i.__mathlib_flt_invalid  m_ps.l(funder.o)
+    0x08002d28   0x0000000e   Code   RO         3505    i.__mathlib_flt_underflow  m_ps.l(funder.o)
+    0x08002d36   0x0000000e   Code   RO         3555    i.__scatterload_copy  mc_p.l(handlers.o)
+    0x08002d44   0x00000002   Code   RO         3556    i.__scatterload_null  mc_p.l(handlers.o)
+    0x08002d46   0x0000000e   Code   RO         3557    i.__scatterload_zeroinit  mc_p.l(handlers.o)
+    0x08002d54   0x0000000c   Code   RO         3537    i.__set_errno       mc_p.l(errno.o)
+    0x08002d60   0x00000118   Code   RO         3459    i.asinf             m_ps.l(asinf.o)
+    0x08002e78   0x0000025c   Code   RO         3467    i.atan2f            m_ps.l(atan2f.o)
+    0x080030d4   0x0000002c   Code   RO         3514    i.sqrtf             m_ps.l(sqrtf.o)
+    0x08003100   0x00000020   Data   RO            5    .constdata          main.o
+    0x08003120   0x00000016   Data   RO          348    .constdata          rfproto.o
+    0x08003136   0x00000002   PAD
+    0x08003138   0x00000020   Data   RO         3553    Region$$Table       anon$$obj.o
 
 
-    Execution Region ER_RW (Base: 0x20000000, Size: 0x00000064, Max: 0xffffffff, ABSOLUTE)
+    Execution Region ER_RW (Base: 0x20000000, Size: 0x00000074, Max: 0xffffffff, ABSOLUTE)
 
     Base Addr    Size         Type   Attr      Idx    E Section Name        Object
 
-    0x20000000   0x00000026   Data   RW            5    .data               main.o
-    0x20000026   0x00000002   Data   RW          142    .data               blinker.o
-    0x20000028   0x00000001   Data   RW          169    .data               mpu6050.o
+    0x20000000   0x00000027   Data   RW            6    .data               main.o
+    0x20000027   0x00000002   Data   RW          142    .data               blinker.o
     0x20000029   0x00000001   PAD
-    0x2000002a   0x00000002   Data   RW          210    .data               timer.o
-    0x2000002c   0x00000008   Data   RW          305    .data               nrf24.o
-    0x20000034   0x00000005   Data   RW          349    .data               rfproto.o
-    0x20000039   0x00000003   PAD
-    0x2000003c   0x00000024   Data   RW          370    .data               imu.o
-    0x20000060   0x00000004   Data   RW         3546    .data               mc_p.l(errno.o)
+    0x2000002a   0x0000000e   Data   RW          169    .data               mpu6050.o
+    0x20000038   0x00000002   Data   RW          210    .data               timer.o
+    0x2000003a   0x00000002   PAD
+    0x2000003c   0x00000008   Data   RW          305    .data               nrf24.o
+    0x20000044   0x00000005   Data   RW          349    .data               rfproto.o
+    0x20000049   0x00000003   PAD
+    0x2000004c   0x00000024   Data   RW          370    .data               imu.o
+    0x20000070   0x00000004   Data   RW         3538    .data               mc_p.l(errno.o)
 
 
-    Execution Region ER_ZI (Base: 0x20000064, Size: 0x0000042c, Max: 0xffffffff, ABSOLUTE)
+    Execution Region ER_ZI (Base: 0x20000074, Size: 0x0000043c, Max: 0xffffffff, ABSOLUTE)
 
     Base Addr    Size         Type   Attr      Idx    E Section Name        Object
 
-    0x20000064   0x00000018   Zero   RW          168    .bss                mpu6050.o
-    0x2000007c   0x00000013   Zero   RW          347    .bss                rfproto.o
-    0x2000008f   0x00000001   PAD
-    0x20000090   0x00000400   Zero   RW         3451    STACK               startup_stm32f0xx_mdk_arm.o
+    0x20000074   0x0000000c   Zero   RW            4    .bss                main.o
+    0x20000080   0x00000018   Zero   RW          168    .bss                mpu6050.o
+    0x20000098   0x00000013   Zero   RW          347    .bss                rfproto.o
+    0x200000ab   0x00000005   PAD
+    0x200000b0   0x00000400   Zero   RW         3451    STACK               startup_stm32f0xx_mdk_arm.o
 
 
 ==============================================================================
@@ -1339,11 +1298,11 @@ Image component sizes
        180         12          0          0          0        680   adc.o
        404         32          0          2          0       1120   blinker.o
       1116         52          0         36          0       1795   imu.o
-      1784        162         32         38          0     200360   main.o
+      1548        142         32         39         12     200442   main.o
        392          6          0          0          0       1571   motorpwm.o
-      1196         50          0          1         24       2317   mpu6050.o
+      1220         60          0         14         24       2261   mpu6050.o
       1092         26          0          8          0       5921   nrf24.o
-      1512        172         22          5         19       2599   rfproto.o
+      1524        174         22          5         19       2607   rfproto.o
         88         38        192          0       1024        596   startup_stm32f0xx_mdk_arm.o
        232          6          0          0          0     155991   stm32f0xx_adc.o
        256          4          0          0          0       2183   stm32f0xx_gpio.o
@@ -1357,9 +1316,9 @@ Image component sizes
        176         14          0          2          0       1168   timer.o
 
     ----------------------------------------------------------------------
-     10548        714        280         96       1068     389422   Object Totals
+     10348        706        280        112       1084     389456   Object Totals
          0          0         32          0          0          0   (incl. Generated)
-         2          0          2          4          1          0   (incl. Padding)
+         2          0          2          6          5          0   (incl. Padding)
 
     ----------------------------------------------------------------------
 
@@ -1383,17 +1342,10 @@ Image component sizes
         40          0          0          0          0         72   idiv.o
         36          8          0          0          0         68   init.o
          0          0          0          0          0          0   iusefp.o
-        32          0          0          0          0         68   llshl.o
-        34          0          0          0          0         68   llushr.o
         36          0          0          0          0         60   memcpya.o
         44          0          0          0          0         72   uidiv.o
         20          0          0          0          0         68   cfcmple.o
         20          0          0          0          0         68   cfrcmple.o
-        56          0          0          0          0         68   d2f.o
-       236          0          0          0          0        216   depilogue.o
-        40          6          0          0          0         68   dflti.o
-       208          6          0          0          0         88   dmul.o
-        40          0          0          0          0         60   f2d.o
        178          0          0          0          0        108   fadd.o
        124          0          0          0          0         72   fdiv.o
        130          0          0          0          0        144   fepilogue.o
@@ -1404,19 +1356,19 @@ Image component sizes
         88          0          0          0          0         72   fsqrt.o
 
     ----------------------------------------------------------------------
-      2652        150          0          4          0       2360   Library Totals
-         4          0          0          0          0          0   (incl. Padding)
+      2004        138          0          4          0       1724   Library Totals
+         2          0          0          0          0          0   (incl. Padding)
 
     ----------------------------------------------------------------------
 
       Code (inc. data)   RO Data    RW Data    ZI Data      Debug   Library Name
 
       1006        116          0          0          0        600   m_ps.l
-       284         22          0          4          0        468   mc_p.l
-      1358         12          0          0          0       1292   mf_p.l
+       218         22          0          4          0        332   mc_p.l
+       778          0          0          0          0        792   mf_p.l
 
     ----------------------------------------------------------------------
-      2652        150          0          4          0       2360   Library Totals
+      2004        138          0          4          0       1724   Library Totals
 
     ----------------------------------------------------------------------
 
@@ -1425,15 +1377,15 @@ Image component sizes
 
       Code (inc. data)   RO Data    RW Data    ZI Data      Debug   
 
-     13200        864        280        100       1068     389674   Grand Totals
-     13200        864        280        100       1068     389674   ELF Image Totals
-     13200        864        280        100          0          0   ROM Totals
+     12352        844        280        116       1084     389468   Grand Totals
+     12352        844        280        116       1084     389468   ELF Image Totals
+     12352        844        280        116          0          0   ROM Totals
 
 ==============================================================================
 
-    Total RO  Size (Code + RO Data)                13480 (  13.16kB)
-    Total RW  Size (RW Data + ZI Data)              1168 (   1.14kB)
-    Total ROM Size (Code + RO Data + RW Data)      13580 (  13.26kB)
+    Total RO  Size (Code + RO Data)                12632 (  12.34kB)
+    Total RW  Size (RW Data + ZI Data)              1200 (   1.17kB)
+    Total ROM Size (Code + RO Data + RW Data)      12748 (  12.45kB)
 
 ==============================================================================
 

--- a/src/MPU6050.c
+++ b/src/MPU6050.c
@@ -55,11 +55,14 @@ void I2C_WrReg(uint8_t Reg, uint8_t Val, int16_t *I2C_Errors){
 
 
 // Returns baseline corrected Gyro and Acc readings
-void ReadMPU(float *gyr, float *acc, int16_t *GyroXYZ, int16_t *ACCXYZ, int16_t *angle, int16_t *I2C_Errors, uint16_t *calibGyroDone)
+void ReadMPU(float *gyr, float *acc, int16_t *I2C_Errors, uint16_t *calibGyroDone)
  {
 	static uint8_t i = 0;
 	static int32_t calibGyro[3] = {0,0,0};
     static int32_t calibAcc[3] = {0,0,0};
+    static int16_t GyroXYZ[3] = {0,0,0};
+    static int16_t ACCXYZ[3] = {0,0,0};
+     
 	uint8_t I2C_rec_Buffer[14];
 	
 	while(I2C_GetFlagStatus(I2C1, I2C_FLAG_BUSY) == SET);
@@ -132,7 +135,7 @@ void ReadMPU(float *gyr, float *acc, int16_t *GyroXYZ, int16_t *ACCXYZ, int16_t 
 		for(i = 0; i<3;i++){
 			GyroXYZ[i] -= calibGyro[i];
             ACCXYZ[i] -= calibAcc[i];
-            gyr[i] = (float)GyroXYZ[i]*0.0010642252f;       // Range = +/- 2000 dps (16.4 LSBs/DPS)
+            gyr[i] = (float)GyroXYZ[i]*0.0010642252f;      // Range = +/- 2000 dps (16.4 LSBs/DPS)
             acc[i] = (float)ACCXYZ[i]*0.00239502f;         // Range = +/- 8 g (4096 lsb/g)
             
 		}

--- a/src/MPU6050.h
+++ b/src/MPU6050.h
@@ -1,6 +1,6 @@
 /*
 	This file is part of STM32F05x brushed Copter FW
-	Copyright © 2014 Felix Niessen ( felix.niessen@googlemail.com )
+	Copyright ï¿½ 2014 Felix Niessen ( felix.niessen@googlemail.com )
 	
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 	You should have received a copy of the GNU General Public License
 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-void ReadMPU(float *gyr, float *acc, int16_t *GyroXYZ, int16_t *ACCXYZ, int16_t *angle, int16_t *I2C_Errors, uint16_t *calibGyroDone);
+void ReadMPU(float *gyr, float *acc, int16_t *I2C_Errors, uint16_t *calibGyroDone);
 void I2C_WrReg(uint8_t Reg, uint8_t Val, int16_t *I2C_Errors);
 void init_MPU6050(int16_t *I2C_Errors);
 long atan2_c(long x , long y);

--- a/src/config.h
+++ b/src/config.h
@@ -25,17 +25,37 @@
 
 // RC Settings
 #define RC_RATE 460         // 100-990
+
+// Rate mode feedforward scaling [%]
 #define RC_ROLL_RATE 88     // 0-100
 #define RC_PITCH_RATE 88    // 0-100
 #define RC_YAW_RATE 88      // 0-100
 
+// Math floating point constants
+#define PI_F                3.14159265358979323f
+#define PI_2_F              1.57079632679489661f
+#define PI_4_F              0.78539816339744830f
+
+// RC calibrated settings
+#define RC_MAX_RPS          8*PI_F          // Maximum rate commanded [rad/s]
+#define RC_MAX_RAD          PI_4_F          // Maximum attitude command [rad]
+
+#define RC_CMD_RPS_SCALE    RC_MAX_RPS/500  // Convert stick to rate in rad/s
+#define RC_CMD_RAD_SCALE    RC_MAX_RAD/500  // Convert stick to attitude in rad
+
+// PWM scaling
+#define PID_PWM_SCALE       100             // Convert rate PID to duty cycle
+
+// Attitude PID (scale [rad] error to [rad/s] setpoint on rate controller)
+#define PID_ATTD_P          RC_MAX_RPS/4
+
 // Channel order (TAER12)
 #define RC_CHAN_ORDER 0,1,2,3,4,5
 
-// Force serial output (pin A9 & A10) 
-// Serial is active by default on REDV1, and can be anabled for other
-// boards, though they cannot be flown whilst in this mode.
-//#define FORCE_SERIAL
+// Array elements
+#define R    0
+#define P    1
+#define Y    2
 
 // Configure radio chipset and protocol according to device
 #ifdef CX10_REDV1
@@ -133,14 +153,8 @@
 #define abs(x) ((x) > 0 ? (x) : -(x))
 #define constrain(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
 
-
 // Global variables
-
-extern int8_t Armed;
 extern int16_t LiPoVolt;
-extern int16_t GyroXYZ[3];
-extern int16_t ACCXYZ[3];
-extern int16_t I2C_Errors;
-extern uint16_t calibGyroDone;
-extern uint8_t failsafe;
-extern int16_t angle[3];
+
+
+

--- a/src/main.c
+++ b/src/main.c
@@ -9,51 +9,58 @@
 
 #include "config.h"
 #include "math.h"
-int16_t LiPoVolt = 0;
-uint8_t failsafe = 100;
-uint8_t mode = 0;
 
+// Globals
+int16_t LiPoVolt = 0;
+
+// State enumerations
 enum states { INIT, BIND, CALIBRATING, DISARMED, ARMED, ARMED_LOWBAT };
 enum fmodes { RATE, ATTITUDE };
 
 int main(void)
 {
-    uint32_t last_Time = 0;
-    int32_t lastError[3] = {0,0,0};
-    int32_t Isum[3] = {0,0,0};
-    int16_t RPY_useRates[3] = {0,0,0};
-    static int16_t setpoint[3] = {0,0,0}; // Static for debug purposes
-    int16_t PIDdata[3] = {0,0,0};
-    int16_t LastDt[3];
+    // Power
     uint16_t LiPoEmptyWaring = 0;
     
+    // Radio & command
+    static const float cmd_rps_scale = RC_CMD_RPS_SCALE;
+    static const float cmd_rad_scale = RC_CMD_RAD_SCALE;
+ 
+    uint8_t failsafe = 100;
     int16_t RXcommands[6] = {0,500,500,500,-500,500};
     
-    int16_t GyroXYZ[3] = {0,0,0};
-    int16_t ACCXYZ[3] = {0,0,0};
-    float gyr[3];   // Gyro readings in rad/s
-    float acc[3];   // Accelerometer readings in m^s^2
-    int16_t angle[3] = {0,0,0};
-    int16_t I2C_Errors = 0;
-    uint16_t calibGyroDone = IMU_CALIB_CYCLES;
-    
-    int32_t timer_imu_start= 0;
-    static int32_t timer_imu =0;
-    
+    // IMU
+    float gyr[3];   // Calibrated gyro readings [rad/s]
+    float acc[3];   // Calibrated accelerometer readings [ms-^2]
     static float imu_pitch, imu_roll, imu_yaw, req_pitch, req_roll;
-    
-    static const uint16_t RC_Rate = RC_RATE;
     static const uint8_t RPY_Rate[3] = {RC_ROLL_RATE,RC_PITCH_RATE,RC_YAW_RATE};
     static const int16_t Imax[3] = {18000,18000,5000};
     static const uint8_t G_P[3] = {GYRO_P_ROLL,GYRO_P_PITCH,GYRO_P_YAW};
     static const uint8_t G_I[3] = {GYRO_I_ROLL,GYRO_I_PITCH,GYRO_I_YAW};
     static const uint8_t G_D[3] = {GYRO_D_ROLL,GYRO_D_PITCH,GYRO_D_YAW};
+    static const float pid_scale = PID_PWM_SCALE;
+    static const float pid_attd_p = PID_ATTD_P;
+    int16_t I2C_Errors = 0;
+    uint16_t calibGyroDone = IMU_CALIB_CYCLES;
     
+    // PID
+    int32_t lastError[3] = {0,0,0};
+    int32_t Isum[3] = {0,0,0};
+    int16_t RPY_useRates[3] = {0,0,0};
+    static float setpoint[3] = {0,0,0}; // Static for debug purposes
+    int16_t PIDdata[3] = {0,0,0};
+    int16_t LastDt[3];
+    
+    // Time
+    static int32_t timer_imu_start = 0;
+    static int32_t timer_imu =0;
     static const uint16_t minCycleTime = 2000;
+    static uint32_t looptime;
+    uint32_t last_Time = 0;
     
+    // Device state and flight mode
     static enum states state = INIT;
     static enum states state_next = INIT;
-    
     static enum fmodes fmode = RATE;
     
     // Startup code calls SystemInit: system clock is configured 
@@ -122,7 +129,7 @@ int main(void)
             case CALIBRATING:
                 // Run calibration cycle, when finished, move to disarmed state
                 set_blink_style(BLINKER_BIND);
-                if(calibGyroDone > 0) ReadMPU(gyr, acc, GyroXYZ, ACCXYZ, angle, &I2C_Errors, &calibGyroDone);
+                if(calibGyroDone > 0) ReadMPU(gyr, acc, &I2C_Errors, &calibGyroDone);
                 else state_next = DISARMED;
                 break;
                            
@@ -130,7 +137,8 @@ int main(void)
                 // Await a valid arming request, move to armed state when received
                 set_blink_style(BLINKER_DISARM);
                 failsafe = rx_rf(RXcommands) ? 0 : constrain(failsafe+1, 0, 100);
-                if(RXcommands[4] > 150 && failsafe < 50 && RXcommands[0] <= 150) state_next = ARMED;    
+                if(RXcommands[4] > 150 && failsafe < 50 && RXcommands[0] <= 150) state_next = ARMED;  
+                if(failsafe > 50) state_next = BIND;            
                 break;
                         
             case ARMED:
@@ -138,7 +146,7 @@ int main(void)
                 // Device is armed, process flight control and write motors, move to
                 // disarm if there is an RF failure or if it commanded.
                 set_blink_style(BLINKER_ON);
-                ReadMPU(gyr, acc, GyroXYZ, ACCXYZ, angle, &I2C_Errors, &calibGyroDone);
+                ReadMPU(gyr, acc, &I2C_Errors, &calibGyroDone);
                 failsafe = rx_rf(RXcommands) ? 0 : constrain(failsafe+1, 0, 100);
                 
                 // Disarm on RF failsafe or user command
@@ -156,7 +164,7 @@ int main(void)
                 // TODO: move configuration to radio
                 if(RXcommands[4] < 250) fmode = RATE;
                 else fmode = ATTITUDE;
-                
+
                 switch(fmode)
                 {
                     case RATE:
@@ -165,42 +173,45 @@ int main(void)
                             // Configure rate controller set-point according to command [rad/s], 
                             // and set feedforward scaline for open loop at maximum commanded rate.
                             
-                            setpoint[i] = ((RXcommands[i+1])*RC_Rate/100);       
+                            setpoint[i] = RXcommands[i+1]*cmd_rps_scale;
                             RPY_useRates[i] = 100-(uint32_t)((abs(RXcommands[i+1])*2)*RPY_Rate[i])/1000;   
                         }   
                         break;
                         
                     case ATTITUDE:
                         
-                        // Configure rate controller [rad/s] according using outer P controller on the 
-                        // attidue error [rad].
+                        // Drive rate controller setpoint [rad/s] with outer controller to minimise
+                        // attitude error [rad].
                     
-                        // Calcualte pitch in degrees (quaternian to Tait-Bryan)
-                        imu_roll  = (180/3.14159) * atan2f(q2*q3 + q0*q1, 0.5f - (q1*q1 + q2*q2));
-                        imu_pitch = (180/3.14159) *  asinf(-2.0f*(q1*q3 - q0*q2));
-                        imu_yaw =   (180/3.14159) * atan2f(q1*q2 + q0*q3, 0.5f - (q2*q2 + q3*q3));
+                        // Calculate IMU RPY (quaternian to Tait-Bryan) [rad]
+                        imu_roll  = atan2f(q2*q3 + q0*q1, 0.5f - (q1*q1 + q2*q2));
+                        imu_pitch = asinf(-2.0f*(q1*q3 - q0*q2));
+                        //imu_yaw =   atan2f(q1*q2 + q0*q3, 0.5f - (q2*q2 + q3*q3));
                     
                         // Calculate commanded attitude [rad]
-                        req_roll = 0.05*RXcommands[1];
-                        req_pitch = 0.05*RXcommands[2];
+                        req_roll =  RXcommands[1]*cmd_rad_scale;
+                        req_pitch = RXcommands[2]*cmd_rad_scale;
                         
-                        // Implement Q&D proprtional controller. Sticks scaled to 25 degrees max.                    
-                        setpoint[0] = 60 * (req_roll-imu_roll);
-                        setpoint[1] = 60 * (req_pitch-imu_pitch);
-                        setpoint[2] = RXcommands[3]*RC_Rate/100;
+                        // Implement Q&D proprtional controller
+                        setpoint[0] = pid_attd_p*(req_roll-imu_roll);
+                        setpoint[1] = pid_attd_p*(req_pitch-imu_pitch);
+
                         
                         // Disable feedforward
                         for(int i=0; i<3; i++) RPY_useRates[i] = 100;
                         break;
                 }
                 
+                // Yaw is always rate mode
+                setpoint[2] = RXcommands[3]*cmd_rps_scale;
                 
                 // PID controller (time is not implemented because of a fix loop time)
                 for(int i=0; i<3; i++)
                 {
-                    // Error
-                    // Gyro is a raw value, max 2000deg/s
-                    int32_t error = setpoint[i]-((GyroXYZ[i])*RPY_useRates[i]/100);
+                    // Error (with feedforward correction)
+                    // Note the correction PID_PWM_SCALE, which allows the old PID gains to be
+                    // employed with the calibrated data.
+                    int32_t error = (setpoint[i]-(gyr[i]*(RPY_useRates[i]/100)))*pid_scale;
                     
                     // Proportional
                     int32_t PT = (error*G_P[i])/100;
@@ -255,7 +266,8 @@ int main(void)
                 break;
                 
         }
-                
+        
+        looptime = micros()-CycleStart;
         while(micros()-CycleStart<minCycleTime);
            
     }


### PR DESCRIPTION
PID still operates in integers through prescaling.

Removed more globals.
